### PR TITLE
Singletons 3 support + misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cabal.project.local
+dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/groebner.cabal
+++ b/groebner.cabal
@@ -45,11 +45,11 @@ library
     , vector >=0.12 && <1
   if impl(ghc >= 9.0)
     build-depends:
-        singletons >= 3.0 && <3.1
-      , singletons-base >= 3.0 && < 3.1
+        singletons ==3.0.*
+      , singletons-base ==3.0.*
   else
     build-depends:
-      singletons >=2.7 && <3
+        singletons >=2.7 && <3
   default-language: Haskell2010
 
 test-suite groebner-test
@@ -70,11 +70,9 @@ test-suite groebner-test
   build-depends:
       HUnit >=1.6 && <2
     , base >=4.7 && <5
-    , criterion >=1.5 && <2
     , groebner
     , hedgehog ==1.*
     , prettyprinter >=1.7 && <2
-    , singletons >=2.7 && <3
     , tasty >=1.4 && <2
     , tasty-hedgehog ==1.*
     , tasty-hunit >=0.10 && <1
@@ -82,6 +80,13 @@ test-suite groebner-test
     , text >=1.2 && <2
     , transformers >=0.5 && <1
     , vector >=0.12 && <1
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons ==3.0.*
+      , singletons-base ==3.0.*
+  else
+    build-depends:
+        singletons >=2.7 && <3
   default-language: Haskell2010
 
 benchmark groebner-bench
@@ -97,18 +102,19 @@ benchmark groebner-bench
       ViewPatterns
   ghc-options: -rtsopts
   build-depends:
-      HUnit >=1.6 && <2
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , criterion >=1.5 && <2
     , groebner
-    , hedgehog ==1.*
     , prettyprinter >=1.7 && <2
-    , singletons >=2.7 && <3
-    , tasty >=1.4 && <2
-    , tasty-hedgehog ==1.*
-    , tasty-hunit >=0.10 && <1
     , template-haskell >=2.16 && <3
     , text >=1.2 && <2
     , transformers >=0.5 && <1
     , vector >=0.12 && <1
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons ==3.0.*
+      , singletons-base ==3.0.*
+  else
+    build-depends:
+        singletons >=2.7 && <3
   default-language: Haskell2010

--- a/groebner.cabal
+++ b/groebner.cabal
@@ -37,19 +37,19 @@ library
       ViewPatterns
   ghc-options: -Wincomplete-patterns
   build-depends:
-      HUnit >=1.6 && <2
-    , base >=4.7 && <5
-    , criterion >=1.5 && <2
-    , hedgehog ==1.*
+      base >=4.7 && <5
     , prettyprinter >=1.7 && <2
-    , singletons >=2.7 && <3
-    , tasty >=1.4 && <2
-    , tasty-hedgehog ==1.*
-    , tasty-hunit >=0.10 && <1
     , template-haskell >=2.16 && <3
     , text >=1.2 && <2
     , transformers >=0.5 && <1
     , vector >=0.12 && <1
+  if impl(ghc >= 9.0)
+    build-depends:
+        singletons >= 3.0 && <3.1
+      , singletons-base >= 3.0 && < 3.1
+  else
+    build-depends:
+      singletons >=2.7 && <3
   default-language: Haskell2010
 
 test-suite groebner-test

--- a/package.yaml
+++ b/package.yaml
@@ -17,17 +17,19 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - vector >= 0.12 && < 1
-- singletons >= 2.7 && < 3
 - prettyprinter >= 1.7 && < 2
 - text >= 1.2 && < 2
 - transformers >= 0.5 && < 1
-- tasty >= 1.4 && < 2
-- tasty-hedgehog >= 1 && < 2
-- hedgehog >= 1 && < 2
-- tasty-hunit >= 0.10 && < 1
-- HUnit >= 1.6 && < 2
-- criterion >= 1.5 && < 2
 - template-haskell >= 2.16 && < 3
+when:
+  - condition: impl(ghc >= 9.0)
+    then:
+      dependencies:
+        - singletons >= 3.0 && < 3.1
+        - singletons-base >= 3.0 && < 3.1
+    else:
+      dependencies:
+        - singletons >= 2.7 && < 3
 
 library:
   source-dirs: src
@@ -42,6 +44,11 @@ tests:
     - -rtsopts
     dependencies:
     - groebner
+    - tasty >= 1.4 && < 2
+    - tasty-hedgehog >= 1 && < 2
+    - hedgehog >= 1 && < 2
+    - tasty-hunit >= 0.10 && < 1
+    - HUnit >= 1.6 && < 2
 
 benchmarks:
   groebner-bench:
@@ -51,6 +58,7 @@ benchmarks:
     - -rtsopts
     dependencies:
     - groebner
+    - criterion >= 1.5 && < 2
 
 default-extensions:
 - ImportQualifiedPost

--- a/src/Poly/Monomial.hs
+++ b/src/Poly/Monomial.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
@@ -30,6 +31,9 @@ import Data.List qualified as L
 import Data.Maybe
 import Data.Vector.Storable qualified as VS
 import Data.Singletons
+#if MIN_VERSION_singletons(3,0,0)
+import GHC.TypeLits.Singletons
+#endif
 
 import Prettyprinter qualified as PP
 import Prettyprinter.Render.String qualified as PP
@@ -45,7 +49,7 @@ newtype Monomial (field :: Type) (vars :: Vars) (order :: Type) =
   MonomialImpl { mData :: MonomialData field }
   deriving (Eq)
 
-
+{-# COMPLETE MonomialVec #-}
 pattern MonomialVec :: f -> VS.Vector Int -> Monomial f v o
 pattern MonomialVec coef powers  = MonomialImpl (MonomialData coef powers)
 
@@ -53,6 +57,7 @@ pattern MonomialVec coef powers  = MonomialImpl (MonomialData coef powers)
 viewMono :: Monomial f v o -> (f, [Int])
 viewMono (MonomialImpl (MonomialData coef powers)) = (coef, VS.toList powers)
 
+{-# COMPLETE Monomial #-}
 pattern Monomial :: f -> [Int] -> Monomial f v o
 pattern Monomial{coef, powers} <- (viewMono -> (coef, powers))
   where


### PR DESCRIPTION
This commit adds support for `singletons-3.0` (for GHC 9.0), plus some miscellaneous fixes:

- add some `COMPLETE` pragmas on some pattern synonyms,
- remove the testing dependencies from the library component in the cabal file.